### PR TITLE
Refactor: Replace 'status' with 'post' and 'note' for clarity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ const CONFIG_FILE: &str = "config.json"; // 設定ファイル名
 const DB_PATH: &str = "cache_db";
 const CACHE_DIR: &str = "cache"; // Re-added for migration
 
-const MAX_STATUS_LENGTH: usize = 140; // ステータス最大文字数
+const MAX_POST_LENGTH: usize = 140; // 投稿の最大文字数
 
 async fn migrate_data_from_files(
     cache_db: &LmdbCache,
@@ -82,12 +82,12 @@ async fn migrate_data_from_files(
 }
 
 // eframe::Appトレイトを実装する構造体
-pub struct NostrStatusApp {
-    data: Arc<Mutex<NostrStatusAppInternal>>,
+pub struct NostrPostApp {
+    data: Arc<Mutex<NostrPostAppInternal>>,
     runtime: Runtime, // Tokio Runtimeを保持
 }
 
-impl NostrStatusApp {
+impl NostrPostApp {
     pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
         let runtime = Runtime::new().expect("Failed to create Tokio runtime");
 
@@ -158,11 +158,11 @@ impl NostrStatusApp {
         let lmdb_cache =
             LmdbCache::new(Path::new(DB_PATH)).expect("Failed to initialize LMDB cache");
 
-        let app_data_internal = NostrStatusAppInternal {
+        let app_data_internal = NostrPostAppInternal {
             nwc_uri_input: String::new(),
             cache_db: lmdb_cache,
             is_logged_in: false,
-            status_message_input: String::new(),
+            post_input: String::new(),
             show_post_dialog: false,
             show_emoji_picker: false,
             my_emojis: HashMap::new(),
@@ -239,6 +239,6 @@ fn main() -> eframe::Result<()> {
     eframe::run_native(
         "N",
         options,
-        Box::new(|cc| Ok(Box::new(NostrStatusApp::new(cc)))),
+        Box::new(|cc| Ok(Box::new(NostrPostApp::new(cc)))),
     )
 }

--- a/src/nostr_client.rs
+++ b/src/nostr_client.rs
@@ -108,13 +108,13 @@ pub async fn fetch_timeline_events(
         .kind(Kind::TextNote)
         .limit(20);
 
-    let status_events = client
+    let note_events = client
         .fetch_events(timeline_filter, Duration::from_secs(10))
         .await?;
 
-    if !status_events.is_empty() {
+    if !note_events.is_empty() {
         let author_pubkeys: HashSet<PublicKey> =
-            status_events.iter().map(|e| e.pubkey).collect();
+            note_events.iter().map(|e| e.pubkey).collect();
         let metadata_filter = Filter::new()
             .authors(author_pubkeys.into_iter())
             .kind(Kind::Metadata);
@@ -128,7 +128,7 @@ pub async fn fetch_timeline_events(
             }
         }
 
-        for event in status_events {
+        for event in note_events {
             let emojis = event
                 .tags
                 .iter()

--- a/src/types.rs
+++ b/src/types.rs
@@ -140,11 +140,11 @@ impl AppTheme {
     }
 }
 
-pub struct NostrStatusAppInternal {
+pub struct NostrPostAppInternal {
     pub nwc_uri_input: String,
     pub cache_db: LmdbCache,
     pub is_logged_in: bool,
-    pub status_message_input: String,
+    pub post_input: String,
     pub show_post_dialog: bool,
     pub show_emoji_picker: bool,
     pub my_emojis: HashMap<String, String>,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,12 +8,12 @@ pub mod zap;
 use eframe::egui::{self, Margin};
 // nostr v0.43.0 / nostr-sdk: RelayMetadata は nostr_sdk::nips::nip65 に移動したため import する
 use crate::{
-    NostrStatusApp,
+    NostrPostApp,
     theme::{dark_visuals, light_visuals},
     types::*,
 };
 
-impl eframe::App for NostrStatusApp {
+impl eframe::App for NostrPostApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         let mut app_data = self.data.lock().unwrap();
 

--- a/src/ui/login_view.rs
+++ b/src/ui/login_view.rs
@@ -9,7 +9,7 @@ use nostr_sdk::{Client, SubscribeAutoCloseOptions};
 use std::str::FromStr;
 
 use crate::{
-    types::{Config, NostrStatusAppInternal, ProfileMetadata, TimelinePost, AppTab},
+    types::{Config, NostrPostAppInternal, ProfileMetadata, TimelinePost, AppTab},
     cache_db::{LmdbCache, DB_FOLLOWED, DB_PROFILES, DB_TIMELINE},
     CONFIG_FILE,
     nostr_client::{connect_to_aggregator_relay, fetch_nip01_profile, fetch_timeline_events}
@@ -118,8 +118,8 @@ async fn fetch_fresh_data_from_network(
 
 pub fn draw_login_view(
     ui: &mut egui::Ui,
-    app_data: &mut NostrStatusAppInternal,
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data: &mut NostrPostAppInternal,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
     runtime_handle: tokio::runtime::Handle,
 ) {
     let login_heading_text = "ログインまたは登録";

--- a/src/ui/profile_view.rs
+++ b/src/ui/profile_view.rs
@@ -12,8 +12,8 @@ use crate::{
 pub fn draw_profile_view(
     ui: &mut egui::Ui,
     ctx: &egui::Context,
-    app_data: &mut NostrStatusAppInternal,
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data: &mut NostrPostAppInternal,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
     runtime_handle: tokio::runtime::Handle,
 ) {
     let mut urls_to_load: Vec<(String, ImageKind)> = Vec::new();
@@ -225,7 +225,7 @@ pub fn draw_profile_view(
                     app_data.followed_pubkeys.clear();
                     app_data.followed_pubkeys_display.clear();
                     app_data.timeline_posts.clear();
-                    app_data.status_message_input.clear();
+                    app_data.post_input.clear();
                     app_data.passphrase_input.clear();
                     app_data.confirm_passphrase_input.clear();
                     app_data.secret_key_input.clear();

--- a/src/ui/wallet_view.rs
+++ b/src/ui/wallet_view.rs
@@ -9,15 +9,15 @@ use std::sync::{Arc, Mutex};
 use tokio::runtime::Handle;
 
 use crate::nostr_client::get_profile_metadata;
-use crate::types::{Config, NostrStatusAppInternal, ProfileMetadata, ZapReceipt};
+use crate::types::{Config, NostrPostAppInternal, ProfileMetadata, ZapReceipt};
 use crate::{nip49, CONFIG_FILE};
 use chrono::{DateTime, Utc};
 use lightning_invoice::Bolt11Invoice;
 
 pub fn draw_wallet_view(
     ui: &mut egui::Ui,
-    app_data: &mut NostrStatusAppInternal,
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data: &mut NostrPostAppInternal,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
     runtime_handle: Handle,
 ) {
     ui.heading("ウォレット");
@@ -42,8 +42,8 @@ pub fn draw_wallet_view(
 
 fn draw_wallet_details(
     ui: &mut egui::Ui,
-    app_data: &mut NostrStatusAppInternal,
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data: &mut NostrPostAppInternal,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
     runtime_handle: Handle,
 ) {
     ui.label("ウォレット接続済み");
@@ -99,8 +99,8 @@ fn draw_wallet_details(
 
 fn draw_setup_view(
     ui: &mut egui::Ui,
-    app_data: &mut NostrStatusAppInternal,
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data: &mut NostrPostAppInternal,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
     runtime_handle: Handle,
 ) {
     ui.label("Nostrウォレットに接続");
@@ -141,7 +141,7 @@ fn draw_setup_view(
 async fn save_and_connect(
     nwc_uri_str: String,
     passphrase: String,
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if passphrase.is_empty() {
         return Err("パスフレーズは空にできません".into());
@@ -171,7 +171,7 @@ async fn save_and_connect(
 
 pub async fn connect_nwc(
     nwc_uri: NostrWalletConnectURI,
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let keys = Keys::new(nwc_uri.secret.clone());
     let client = Client::new(keys);
@@ -212,7 +212,7 @@ pub async fn connect_nwc(
 async fn listen_for_nwc_responses(
     _client: Client,
     _nwc: NostrWalletConnectURI,
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
 ) {
     // We keep the listener active for potential future uses,
     // like real-time updates, but for now it only handles PayInvoice responses.
@@ -249,7 +249,7 @@ async fn listen_for_nwc_responses(
 }
 
 async fn get_zap_history(
-    app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (client, my_pubkey) = {
         let mut app_data = app_data_arc.lock().unwrap();


### PR DESCRIPTION
This commit builds upon the previous refactoring that removed misleading NIP-38 references. It replaces the ambiguous term "status" with more precise terms like "post" (for UI elements) and "note" (for internal logic) to better align with Nostr's terminology for `Kind:1` events.

Changes include:
- Renamed core application structs from `NostrStatusApp` to `NostrPostApp`.
- Renamed variables like `status_message_input` to `post_input`.
- Updated UI text and hints to refer to "posts" (投稿) instead of "statuses".
- Updated log messages for better clarity.
- Renamed event-related variables from `status_events` to `note_events`.

This makes the codebase more consistent and easier to understand for developers familiar with Nostr protocols.