### PR TITLE
fix: 設定保存時に秘密鍵が上書きされる問題を修正

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -9,12 +9,31 @@ use crate::cache_db::LmdbCache;
 
 // --- Pub-used structs and enums ---
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Default, Debug)]
+pub struct RelayConfig {
+    #[serde(default)]
+    pub aggregator: Vec<String>,
+    #[serde(default)]
+    pub self_hosted: Vec<String>,
+    #[serde(default)]
+    pub search: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Config {
+    #[serde(default)]
     pub encrypted_secret_key: String,
+    #[serde(default)]
     pub salt: String,
     #[serde(default)]
     pub encrypted_nwc_uri: Option<String>,
+    // The `relays` field is now a struct, but we want to be able to deserialize
+    // old configs where it was a `Vec<String>`. We handle this in `main.rs:load_config`.
+    // For new configs, it will be a `RelayConfig`.
+    #[serde(default)]
+    pub relays: serde_json::Value,
+    #[serde(default)]
+    pub theme: Option<AppTheme>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -102,6 +121,7 @@ pub enum AppTab {
     Home,
     Wallet,
     Profile,
+    Settings,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
@@ -178,4 +198,10 @@ pub struct NostrPostAppInternal {
     pub show_zap_dialog: bool,
     pub zap_amount_input: String,
     pub zap_target_post: Option<TimelinePost>,
+
+    // Settings
+    pub relays: RelayConfig,
+    pub aggregator_relay_input: String,
+    pub self_hosted_relay_input: String,
+    pub search_relay_input: String,
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,6 +4,7 @@ pub mod profile_view;
 pub mod wallet_view;
 pub mod image_cache;
 pub mod zap;
+pub mod settings_view;
 
 use eframe::egui::{self, Margin};
 // nostr v0.43.0 / nostr-sdk: RelayMetadata は nostr_sdk::nips::nip65 に移動したため import する
@@ -20,6 +21,7 @@ impl eframe::App for NostrPostApp {
         let home_tab_text = "ホーム";
         let wallet_tab_text = "ウォレット";
         let profile_tab_text = "プロフィール";
+        let settings_tab_text = "設定";
 
         // app_data_arc をクローンして非同期タスクに渡す
         let app_data_arc_clone = self.data.clone();
@@ -70,6 +72,11 @@ impl eframe::App for NostrPostApp {
                             AppTab::Profile,
                             profile_tab_text,
                         );
+                        ui.selectable_value(
+                            &mut app_data.current_tab,
+                            AppTab::Settings,
+                            settings_tab_text,
+                        );
                     }
                 });
 
@@ -108,6 +115,9 @@ impl eframe::App for NostrPostApp {
                         AppTab::Profile => {
                             profile_view::draw_profile_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);
                         },
+                        AppTab::Settings => {
+                            settings_view::draw_settings_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);
+                        }
                     }
                 }
             // }); // この閉じ括弧も削除

--- a/src/ui/home_view.rs
+++ b/src/ui/home_view.rs
@@ -406,13 +406,14 @@ pub fn draw_home_view(
             let fetch_button = egui::Button::new(egui::RichText::new(fetch_latest_button_text).strong());
             if ui.add_enabled(!app_data.is_loading, fetch_button).clicked() {
                 let client = app_data.nostr_client.as_ref().unwrap().clone();
+                let aggregator_relays = app_data.relays.aggregator.clone();
 
                 app_data.is_loading = true;
                 app_data.should_repaint = true;
 
                 let cloned_app_data_arc = app_data_arc.clone();
                 runtime_handle.spawn(async move {
-                    let timeline_result = fetch_timeline_events(&client).await;
+                    let timeline_result = fetch_timeline_events(&client, aggregator_relays).await;
 
                     let mut app_data_async = cloned_app_data_arc.lock().unwrap();
                     app_data_async.is_loading = false;

--- a/src/ui/settings_view.rs
+++ b/src/ui/settings_view.rs
@@ -1,0 +1,139 @@
+use eframe::egui;
+use std::sync::{Arc, Mutex};
+use tokio::runtime::Handle;
+
+use crate::{
+    nostr_client::switch_relays,
+    save_config,
+    types::{AppTheme, NostrPostAppInternal},
+};
+
+pub fn draw_settings_view(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    app_data: &mut NostrPostAppInternal,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
+    runtime_handle: Handle,
+) {
+    ui.heading("設定");
+    ui.add_space(10.0);
+
+    // --- テーマ設定 ---
+    ui.label("テーマ");
+    if ui
+        .selectable_value(&mut app_data.current_theme, AppTheme::Light, "ライト")
+        .clicked()
+        || ui
+            .selectable_value(&mut app_data.current_theme, AppTheme::Dark, "ダーク")
+            .clicked()
+    {
+        update_theme(app_data.current_theme, ctx);
+        save_config(app_data);
+    }
+
+    ui.add_space(20.0);
+    ui.separator();
+    ui.add_space(20.0);
+
+    // --- リレー設定 ---
+    ui.heading("リレー設定");
+    ui.add_space(10.0);
+
+    let mut changed = false;
+
+    changed |= draw_relay_category(
+        ui,
+        "アグリゲーターリレー",
+        "タイムラインの取得元となるリレーです。",
+        &mut app_data.relays.aggregator,
+        &mut app_data.aggregator_relay_input,
+    );
+
+    ui.add_space(15.0);
+
+    changed |= draw_relay_category(
+        ui,
+        "セルフホストリレー",
+        "投稿の送信先となる、自分用のリレーです。",
+        &mut app_data.relays.self_hosted,
+        &mut app_data.self_hosted_relay_input,
+    );
+
+    ui.add_space(15.0);
+
+    changed |= draw_relay_category(
+        ui,
+        "サーチリレー",
+        "検索機能などで使われるリレーです。",
+        &mut app_data.relays.search,
+        &mut app_data.search_relay_input,
+    );
+
+    if changed {
+        save_config(app_data);
+        let app_data_clone = app_data_arc.clone();
+        runtime_handle.spawn(async move {
+            switch_relays(app_data_clone).await;
+        });
+    }
+}
+
+fn draw_relay_category(
+    ui: &mut egui::Ui,
+    title: &str,
+    description: &str,
+    relays: &mut Vec<String>,
+    relay_input: &mut String,
+) -> bool {
+    let mut changed = false;
+
+    ui.label(egui::RichText::new(title).strong());
+    ui.label(egui::RichText::new(description).small().color(egui::Color32::GRAY));
+    ui.add_space(5.0);
+
+    // 新しいリレーの追加
+    ui.horizontal(|ui| {
+        let response = ui.text_edit_singleline(relay_input);
+        if ui.button("追加").clicked()
+            || (response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)))
+        {
+            if !relay_input.trim().is_empty() {
+                let new_relay = relay_input.trim().to_string();
+                if !relays.contains(&new_relay) {
+                    relays.push(new_relay);
+                    relay_input.clear();
+                    changed = true;
+                }
+            }
+        }
+    });
+
+    // 現在のリレーリスト
+    let mut relay_to_remove = None;
+    for (i, relay) in relays.iter().enumerate() {
+        ui.horizontal(|ui| {
+            ui.label(relay);
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui.button("削除").clicked() {
+                    relay_to_remove = Some(i);
+                }
+            });
+        });
+    }
+
+    if let Some(i) = relay_to_remove {
+        relays.remove(i);
+        changed = true;
+    }
+
+    changed
+}
+
+
+fn update_theme(theme: AppTheme, ctx: &egui::Context) {
+    let visuals = match theme {
+        AppTheme::Light => crate::theme::light_visuals(),
+        AppTheme::Dark => crate::theme::dark_visuals(),
+    };
+    ctx.set_visuals(visuals);
+}


### PR DESCRIPTION
設定画面でリレーやテーマを変更して保存する際に、既存の `config.json` ファイルから秘密鍵やソルトの情報を読み込まず、空の状態で上書きしてしまっていた問題を修正しました。

`save_config` 関数が、まず既存の設定を読み込み、その上でリレーとテーマの情報のみを更新してから書き戻すようにロジックを変更しました。

これにより、設定を変更した後でも、ユーザーは再度正常にログインできるようになります。