### PR TITLE
feat: Add search tab and functionality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,8 @@ impl NostrPostApp {
             aggregator_relay_input: String::new(),
             self_hosted_relay_input: String::new(),
             search_relay_input: String::new(),
+            search_input: String::new(),
+            search_results: Vec::new(),
         };
         let data = Arc::new(Mutex::new(app_data_internal));
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -119,6 +119,7 @@ pub struct TimelinePost {
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum AppTab {
     Home,
+    Search,
     Wallet,
     Profile,
     Settings,
@@ -204,4 +205,8 @@ pub struct NostrPostAppInternal {
     pub aggregator_relay_input: String,
     pub self_hosted_relay_input: String,
     pub search_relay_input: String,
+
+    // Search
+    pub search_input: String,
+    pub search_results: Vec<TimelinePost>,
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,6 +5,7 @@ pub mod wallet_view;
 pub mod image_cache;
 pub mod zap;
 pub mod settings_view;
+pub mod search_view;
 
 use eframe::egui::{self, Margin};
 // nostr v0.43.0 / nostr-sdk: RelayMetadata は nostr_sdk::nips::nip65 に移動したため import する
@@ -19,6 +20,7 @@ impl eframe::App for NostrPostApp {
         let mut app_data = self.data.lock().unwrap();
 
         let home_tab_text = "ホーム";
+        let search_tab_text = "検索";
         let wallet_tab_text = "ウォレット";
         let profile_tab_text = "プロフィール";
         let settings_tab_text = "設定";
@@ -62,6 +64,11 @@ impl eframe::App for NostrPostApp {
 
                     ui.selectable_value(&mut app_data.current_tab, AppTab::Home, home_tab_text);
                     if app_data.is_logged_in {
+                        ui.selectable_value(
+                            &mut app_data.current_tab,
+                            AppTab::Search,
+                            search_tab_text,
+                        );
                         ui.selectable_value(
                             &mut app_data.current_tab,
                             AppTab::Wallet,
@@ -108,6 +115,9 @@ impl eframe::App for NostrPostApp {
                     match app_data.current_tab {
                         AppTab::Home => {
                             home_view::draw_home_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);
+                        },
+                        AppTab::Search => {
+                            search_view::draw_search_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);
                         },
                         AppTab::Wallet => {
                             wallet_view::draw_wallet_view(ui, &mut app_data, app_data_arc_clone, runtime_handle);

--- a/src/ui/search_view.rs
+++ b/src/ui/search_view.rs
@@ -1,0 +1,66 @@
+use std::sync::{Arc, Mutex};
+use eframe::egui;
+use tokio::runtime::Handle;
+use crate::{
+    NostrPostAppInternal,
+    nostr_client::search_events,
+};
+
+pub fn draw_search_view(
+    ui: &mut egui::Ui,
+    _ctx: &egui::Context,
+    app_data: &mut NostrPostAppInternal,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
+    runtime_handle: Handle,
+) {
+    // --- Search bar and button ---
+    ui.horizontal(|ui| {
+        ui.label("検索:");
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if ui.button("検索").clicked() {
+                let query = app_data.search_input.clone();
+                if !query.is_empty() {
+                    app_data.is_loading = true;
+                    app_data.search_results.clear();
+                    let search_relays = app_data.relays.search.clone();
+                    let app_data_clone = app_data_arc.clone();
+                    runtime_handle.spawn(async move {
+                        let results = match search_events(search_relays, query).await {
+                            Ok(posts) => posts,
+                            Err(e) => {
+                                eprintln!("Search failed: {}", e);
+                                // Optionally, set an error message in app_data to show in the UI
+                                Vec::new()
+                            }
+                        };
+                        let mut data = app_data_clone.lock().unwrap();
+                        data.search_results = results;
+                        data.is_loading = false;
+                        data.should_repaint = true;
+                    });
+                }
+            }
+            ui.add(
+                egui::TextEdit::singleline(&mut app_data.search_input)
+                    .hint_text("キーワードを入力...")
+                    .desired_width(ui.available_width()),
+            );
+        });
+    });
+
+    ui.add_space(10.0);
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        if app_data.is_loading {
+            ui.spinner();
+        } else if app_data.search_results.is_empty() {
+            ui.label("検索結果はありません。");
+        } else {
+            for post in &app_data.search_results {
+                // Here you would draw each post.
+                // For now, we'll just show the content as a label.
+                ui.label(&post.content);
+                ui.separator();
+            }
+        }
+    });
+}


### PR DESCRIPTION
- Adds a new 'Search' tab to the left-side panel, positioned below 'Home'.
- Implements a search view with a search bar and a results area.
- Adds a `search_events` function to `nostr_client.rs` to fetch posts from configured search relays based on a query.
- Updates `types.rs` and `main.rs` to support the new search state and functionality.