### PR TITLE
投稿レンダリングをリファクタリングし、検索ビューを強化

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,12 @@
-pub mod login_view;
 pub mod home_view;
-pub mod profile_view;
-pub mod wallet_view;
 pub mod image_cache;
-pub mod zap;
-pub mod settings_view;
+pub mod login_view;
+pub mod post;
+pub mod profile_view;
 pub mod search_view;
+pub mod settings_view;
+pub mod wallet_view;
+pub mod zap;
 
 use eframe::egui::{self, Margin};
 // nostr v0.43.0 / nostr-sdk: RelayMetadata は nostr_sdk::nips::nip65 に移動したため import する

--- a/src/ui/home_view.rs
+++ b/src/ui/home_view.rs
@@ -1,115 +1,14 @@
 use eframe::egui;
-use std::sync::{Arc, Mutex};
-use std::collections::HashMap;
-use nostr::{EventBuilder, Kind, Tag, nips::nip19::ToBech32, EventId};
+use nostr::{nips::nip19::ToBech32, EventBuilder, EventId, Kind, Tag};
 use regex::Regex;
+use std::sync::{Arc, Mutex};
 
 use crate::{
-    types::*,
     nostr_client::fetch_timeline_events,
+    types::*,
+    ui::{image_cache, post, zap},
     MAX_POST_LENGTH,
-    ui::{image_cache, zap},
 };
-
-fn render_post_content(
-    ui: &mut egui::Ui,
-    app_data: &NostrPostAppInternal,
-    post: &TimelinePost,
-    urls_to_load: &mut Vec<(String, ImageKind)>,
-    my_emojis: &HashMap<String, String>,
-) {
-    let text_color = app_data.current_theme.text_color();
-
-    // Check for music/podcast status
-    let d_tag = post
-        .tags
-        .iter()
-        .find(|t| (*t).clone().to_vec().get(0).map(|s| s.as_str()) == Some("d"));
-
-    if let Some(tag) = d_tag {
-        let tag_vec = tag.clone().to_vec();
-        if tag_vec.get(1).map(|s| s.as_str()) == Some("music") {
-            // Music or Podcast status
-            ui.horizontal(|ui| {
-                ui.label("🎵"); // Use a general music icon for now
-                ui.vertical(|ui| {
-                    ui.label(egui::RichText::new(&post.content).color(text_color));
-                    let r_tag = post
-                        .tags
-                        .iter()
-                        .find(|t| (*t).clone().to_vec().get(0).map(|s| s.as_str()) == Some("r"));
-                    if let Some(r_tag_value) = r_tag.and_then(|t| t.clone().to_vec().get(1).cloned()) {
-                        ui.hyperlink_to(
-                            egui::RichText::new(&r_tag_value).small().color(egui::Color32::GRAY),
-                            r_tag_value,
-                        );
-                    }
-                });
-            });
-            return; // Don't render general content
-        }
-    }
-
-    // General status (with emojis)
-    let re = Regex::new(r":(\w+):").unwrap();
-    let mut last_end = 0;
-
-    ui.horizontal_wrapped(|ui| {
-        for cap in re.captures_iter(&post.content) {
-            let full_match = cap.get(0).unwrap();
-            let shortcode = cap.get(1).unwrap().as_str();
-
-            let pre_text = &post.content[last_end..full_match.start()];
-            if !pre_text.is_empty() {
-                ui.label(egui::RichText::new(pre_text).color(text_color));
-            }
-
-            let url = post.emojis.get(shortcode).or_else(|| my_emojis.get(shortcode));
-            if let Some(url) = url {
-                let emoji_size = egui::vec2(20.0, 20.0);
-                let url_key = url.to_string();
-
-                match app_data.image_cache.get(&url_key) {
-                    Some(ImageState::Loaded(texture_handle)) => {
-                        let image_widget =
-                            egui::Image::new(texture_handle).fit_to_exact_size(emoji_size);
-                        ui.add(image_widget);
-                    }
-                    Some(ImageState::Loading) => {
-                        let (rect, _) = ui.allocate_exact_size(emoji_size, egui::Sense::hover());
-                        ui.put(rect, egui::Spinner::new());
-                    }
-                    Some(ImageState::Failed) => {
-                        let (rect, _) = ui.allocate_exact_size(emoji_size, egui::Sense::hover());
-                        ui.painter().text(
-                            rect.center(),
-                            egui::Align2::CENTER_CENTER,
-                            "💔".to_string(),
-                            egui::FontId::default(),
-                            ui.visuals().error_fg_color,
-                        );
-                    }
-                    None => {
-                        if !urls_to_load.iter().any(|(u, _)| u == &url_key) {
-                            urls_to_load.push((url_key.clone(), ImageKind::Emoji));
-                        }
-                        let (rect, _) = ui.allocate_exact_size(emoji_size, egui::Sense::hover());
-                        ui.put(rect, egui::Spinner::new());
-                    }
-                }
-            } else {
-                ui.label(egui::RichText::new(full_match.as_str()).color(text_color));
-            }
-
-            last_end = full_match.end();
-        }
-
-        let remaining_text = &post.content[last_end..];
-        if !remaining_text.is_empty() {
-            ui.label(egui::RichText::new(remaining_text).color(text_color));
-        }
-    });
-}
 
 pub fn draw_home_view(
     ui: &mut egui::Ui,
@@ -127,13 +26,6 @@ pub fn draw_home_view(
     let fetch_latest_button_text = "最新の投稿を取得";
     let no_timeline_message_text = "タイムラインに投稿はまだありません。";
 
-    let card_frame = egui::Frame {
-        inner_margin: egui::Margin::same(12),
-        corner_radius: 8.0.into(),
-        shadow: eframe::epaint::Shadow::NONE,
-        fill: app_data.current_theme.card_background_color(),
-        ..Default::default()
-    };
 
     // --- ZAP Dialog ---
     if app_data.show_zap_dialog {
@@ -399,6 +291,13 @@ pub fn draw_home_view(
         }
     }
 
+    let card_frame = egui::Frame {
+        inner_margin: egui::Margin::same(12),
+        corner_radius: 8.0.into(),
+        shadow: eframe::epaint::Shadow::NONE,
+        fill: app_data.current_theme.card_background_color(),
+        ..Default::default()
+    };
     card_frame.show(ui, |ui| {
         ui.horizontal(|ui| {
             ui.heading(timeline_heading_text);
@@ -462,84 +361,25 @@ pub fn draw_home_view(
             let num_posts = app_data.timeline_posts.len();
             let row_height = 90.0;
 
-            egui::ScrollArea::vertical()
-                .id_salt("timeline_scroll_area")
-                .max_height(ui.available_height() - 100.0)
-                .show_rows(ui, row_height, num_posts, |ui, row_range| {
-                    for i in row_range {
-                        let post = app_data.timeline_posts[i].clone();
-                        card_frame.show(ui, |ui| {
-                            ui.horizontal(|ui| {
-                                let avatar_size = egui::vec2(32.0, 32.0);
-                                let corner_radius = 4.0;
-                                let url = &post.author_metadata.picture;
-
-                                if !url.is_empty() {
-                                    let url_key = url.to_string();
-                                    let image_state = app_data.image_cache.get(&url_key).cloned();
-
-                                    match image_state {
-                                        Some(ImageState::Loaded(texture_handle)) => {
-                                            let image_widget = egui::Image::new(&texture_handle)
-                                                .corner_radius(corner_radius)
-                                                .fit_to_exact_size(avatar_size);
-                                            ui.add(image_widget);
-                                        }
-                                        Some(ImageState::Loading) => {
-                                            let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
-                                            ui.painter().rect_filled(rect, corner_radius, ui.style().visuals.widgets.inactive.bg_fill);
-                                            ui.put(rect, egui::Spinner::new());
-                                        }
-                                        Some(ImageState::Failed) => {
-                                            let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
-                                            ui.painter().rect_filled(rect, corner_radius, ui.style().visuals.error_fg_color.linear_multiply(0.2));
-                                        }
-                                        None => {
-                                            if !urls_to_load.iter().any(|(u, _)| u == &url_key) {
-                                                urls_to_load.push((url_key.clone(), ImageKind::Avatar));
-                                            }
-                                            let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
-                                            ui.painter().rect_filled(rect, corner_radius, ui.style().visuals.widgets.inactive.bg_fill);
-                                            ui.put(rect, egui::Spinner::new());
-                                        }
-                                    }
-                                } else {
-                                    let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
-                                    ui.painter().rect_filled(rect, corner_radius, ui.style().visuals.widgets.inactive.bg_fill);
-                                }
-
-                                ui.add_space(8.0);
-
-                                let display_name = if !post.author_metadata.name.is_empty() {
-                                    post.author_metadata.name.clone()
-                                } else {
-                                    let pubkey = post.author_pubkey.to_bech32().unwrap_or_default();
-                                    format!("{}...{}", &pubkey[0..8], &pubkey[pubkey.len()-4..])
-                                };
-                                ui.label(egui::RichText::new(display_name).strong().color(app_data.current_theme.text_color()));
-
-                                let created_at_datetime = chrono::DateTime::from_timestamp(post.created_at.as_u64() as i64, 0).unwrap();
-                                let local_datetime = created_at_datetime.with_timezone(&chrono::Local);
-                                ui.label(egui::RichText::new(local_datetime.format("%Y-%m-%d %H:%M:%S").to_string()).color(egui::Color32::GRAY).small());
-
-                                if let Some(my_keys) = &app_data.my_keys {
-                                    if post.author_pubkey != my_keys.public_key() {
-                                        // ZAP button
-                                        if !post.author_metadata.lud16.is_empty() {
-                                            if ui.button("⚡").clicked() {
-                                                app_data.zap_target_post = Some(post.clone());
-                                                app_data.show_zap_dialog = true;
-                                                app_data.zap_amount_input = "21".to_string(); // Default amount
-                                            }
-                                        }
-                                    }
-                                }
-                            });
+            let card_frame = egui::Frame {
+                inner_margin: egui::Margin::same(0),
+                corner_radius: 8.0.into(),
+                shadow: eframe::epaint::Shadow::NONE,
+                fill: app_data.current_theme.card_background_color(),
+                ..Default::default()
+            };
+            card_frame.show(ui, |ui| {
+                egui::ScrollArea::vertical()
+                    .id_salt("timeline_scroll_area")
+                    .max_height(ui.available_height() - 100.0)
+                    .show_rows(ui, row_height, num_posts, |ui, row_range| {
+                        for i in row_range {
+                            let post_data = app_data.timeline_posts[i].clone();
+                            post::render_post(ui, app_data, &post_data, &mut urls_to_load);
                             ui.add_space(5.0);
-                            render_post_content(ui, app_data, &post, &mut urls_to_load, &app_data.my_emojis);
-                        });
-                    }
-                });
+                        }
+                    });
+            });
         }
 
         // --- Image Loading Logic ---

--- a/src/ui/post.rs
+++ b/src/ui/post.rs
@@ -1,0 +1,229 @@
+use eframe::egui;
+use nostr::nips::nip19::ToBech32;
+use regex::Regex;
+use std::collections::HashMap;
+
+use crate::types::{ImageKind, ImageState, NostrPostAppInternal, TimelinePost};
+
+fn render_post_content(
+    ui: &mut egui::Ui,
+    app_data: &NostrPostAppInternal,
+    post: &TimelinePost,
+    urls_to_load: &mut Vec<(String, ImageKind)>,
+    my_emojis: &HashMap<String, String>,
+) {
+    let text_color = app_data.current_theme.text_color();
+
+    // Check for music/podcast status
+    let d_tag = post
+        .tags
+        .iter()
+        .find(|t| (*t).clone().to_vec().get(0).map(|s| s.as_str()) == Some("d"));
+
+    if let Some(tag) = d_tag {
+        let tag_vec = tag.clone().to_vec();
+        if tag_vec.get(1).map(|s| s.as_str()) == Some("music") {
+            // Music or Podcast status
+            ui.horizontal(|ui| {
+                ui.label("🎵"); // Use a general music icon for now
+                ui.vertical(|ui| {
+                    ui.label(egui::RichText::new(&post.content).color(text_color));
+                    let r_tag = post
+                        .tags
+                        .iter()
+                        .find(|t| (*t).clone().to_vec().get(0).map(|s| s.as_str()) == Some("r"));
+                    if let Some(r_tag_value) = r_tag.and_then(|t| t.clone().to_vec().get(1).cloned())
+                    {
+                        ui.hyperlink_to(
+                            egui::RichText::new(&r_tag_value)
+                                .small()
+                                .color(egui::Color32::GRAY),
+                            r_tag_value,
+                        );
+                    }
+                });
+            });
+            return; // Don't render general content
+        }
+    }
+
+    // General status (with emojis)
+    let re = Regex::new(r":(\w+):").unwrap();
+    let mut last_end = 0;
+
+    ui.horizontal_wrapped(|ui| {
+        for cap in re.captures_iter(&post.content) {
+            let full_match = cap.get(0).unwrap();
+            let shortcode = cap.get(1).unwrap().as_str();
+
+            let pre_text = &post.content[last_end..full_match.start()];
+            if !pre_text.is_empty() {
+                ui.label(egui::RichText::new(pre_text).color(text_color));
+            }
+
+            let url = post
+                .emojis
+                .get(shortcode)
+                .or_else(|| my_emojis.get(shortcode));
+            if let Some(url) = url {
+                let emoji_size = egui::vec2(20.0, 20.0);
+                let url_key = url.to_string();
+
+                match app_data.image_cache.get(&url_key) {
+                    Some(ImageState::Loaded(texture_handle)) => {
+                        let image_widget =
+                            egui::Image::new(texture_handle).fit_to_exact_size(emoji_size);
+                        ui.add(image_widget);
+                    }
+                    Some(ImageState::Loading) => {
+                        let (rect, _) = ui.allocate_exact_size(emoji_size, egui::Sense::hover());
+                        ui.put(rect, egui::Spinner::new());
+                    }
+                    Some(ImageState::Failed) => {
+                        let (rect, _) = ui.allocate_exact_size(emoji_size, egui::Sense::hover());
+                        ui.painter().text(
+                            rect.center(),
+                            egui::Align2::CENTER_CENTER,
+                            "💔".to_string(),
+                            egui::FontId::default(),
+                            ui.visuals().error_fg_color,
+                        );
+                    }
+                    None => {
+                        if !urls_to_load.iter().any(|(u, _)| u == &url_key) {
+                            urls_to_load.push((url_key.clone(), ImageKind::Emoji));
+                        }
+                        let (rect, _) = ui.allocate_exact_size(emoji_size, egui::Sense::hover());
+                        ui.put(rect, egui::Spinner::new());
+                    }
+                }
+            } else {
+                ui.label(egui::RichText::new(full_match.as_str()).color(text_color));
+            }
+
+            last_end = full_match.end();
+        }
+
+        let remaining_text = &post.content[last_end..];
+        if !remaining_text.is_empty() {
+            ui.label(egui::RichText::new(remaining_text).color(text_color));
+        }
+    });
+}
+
+pub fn render_post(
+    ui: &mut egui::Ui,
+    app_data: &mut NostrPostAppInternal,
+    post: &TimelinePost,
+    urls_to_load: &mut Vec<(String, ImageKind)>,
+) {
+    let card_frame = egui::Frame {
+        inner_margin: egui::Margin::same(12),
+        corner_radius: 8.0.into(),
+        shadow: eframe::epaint::Shadow::NONE,
+        fill: app_data.current_theme.card_background_color(),
+        ..Default::default()
+    };
+
+    card_frame.show(ui, |ui| {
+        ui.horizontal(|ui| {
+            let avatar_size = egui::vec2(32.0, 32.0);
+            let corner_radius = 4.0;
+            let url = &post.author_metadata.picture;
+
+            if !url.is_empty() {
+                let url_key = url.to_string();
+                let image_state = app_data.image_cache.get(&url_key).cloned();
+
+                match image_state {
+                    Some(ImageState::Loaded(texture_handle)) => {
+                        let image_widget = egui::Image::new(&texture_handle)
+                            .corner_radius(corner_radius)
+                            .fit_to_exact_size(avatar_size);
+                        ui.add(image_widget);
+                    }
+                    Some(ImageState::Loading) => {
+                        let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
+                        ui.painter().rect_filled(
+                            rect,
+                            corner_radius,
+                            ui.style().visuals.widgets.inactive.bg_fill,
+                        );
+                        ui.put(rect, egui::Spinner::new());
+                    }
+                    Some(ImageState::Failed) => {
+                        let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
+                        ui.painter().rect_filled(
+                            rect,
+                            corner_radius,
+                            ui.style().visuals.error_fg_color.linear_multiply(0.2),
+                        );
+                    }
+                    None => {
+                        if !urls_to_load.iter().any(|(u, _)| u == &url_key) {
+                            urls_to_load.push((url_key.clone(), ImageKind::Avatar));
+                        }
+                        let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
+                        ui.painter().rect_filled(
+                            rect,
+                            corner_radius,
+                            ui.style().visuals.widgets.inactive.bg_fill,
+                        );
+                        ui.put(rect, egui::Spinner::new());
+                    }
+                }
+            } else {
+                let (rect, _) = ui.allocate_exact_size(avatar_size, egui::Sense::hover());
+                ui.painter().rect_filled(
+                    rect,
+                    corner_radius,
+                    ui.style().visuals.widgets.inactive.bg_fill,
+                );
+            }
+
+            ui.add_space(8.0);
+
+            let display_name = if !post.author_metadata.name.is_empty() {
+                post.author_metadata.name.clone()
+            } else {
+                let pubkey = post.author_pubkey.to_bech32().unwrap_or_default();
+                format!("{}...{}", &pubkey[0..8], &pubkey[pubkey.len() - 4..])
+            };
+            ui.label(
+                egui::RichText::new(display_name)
+                    .strong()
+                    .color(app_data.current_theme.text_color()),
+            );
+
+            let created_at_datetime =
+                chrono::DateTime::from_timestamp(post.created_at.as_u64() as i64, 0).unwrap();
+            let local_datetime = created_at_datetime.with_timezone(&chrono::Local);
+            ui.label(
+                egui::RichText::new(local_datetime.format("%Y-%m-%d %H:%M:%S").to_string())
+                    .color(egui::Color32::GRAY)
+                    .small(),
+            );
+
+            if let Some(my_keys) = &app_data.my_keys {
+                if post.author_pubkey != my_keys.public_key() {
+                    // ZAP button
+                    if !post.author_metadata.lud16.is_empty() {
+                        if ui.button("⚡").clicked() {
+                            app_data.zap_target_post = Some(post.clone());
+                            app_data.show_zap_dialog = true;
+                            app_data.zap_amount_input = "21".to_string(); // Default amount
+                        }
+                    }
+                }
+            }
+        });
+        ui.add_space(5.0);
+        render_post_content(
+            ui,
+            app_data,
+            post,
+            urls_to_load,
+            &app_data.my_emojis.clone(),
+        );
+    });
+}

--- a/src/ui/search_view.rs
+++ b/src/ui/search_view.rs
@@ -1,18 +1,20 @@
-use std::sync::{Arc, Mutex};
-use eframe::egui;
-use tokio::runtime::Handle;
 use crate::{
-    NostrPostAppInternal,
     nostr_client::search_events,
+    types::{ImageKind, ImageState, NostrPostAppInternal},
+    ui::{image_cache, post},
 };
+use eframe::egui;
+use std::sync::{Arc, Mutex};
+use tokio::runtime::Handle;
 
 pub fn draw_search_view(
     ui: &mut egui::Ui,
-    _ctx: &egui::Context,
+    ctx: &egui::Context,
     app_data: &mut NostrPostAppInternal,
     app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
     runtime_handle: Handle,
 ) {
+    let mut urls_to_load: Vec<(String, ImageKind)> = Vec::new();
     // --- Search bar and button ---
     ui.horizontal(|ui| {
         ui.label("検索:");
@@ -49,18 +51,125 @@ pub fn draw_search_view(
     });
 
     ui.add_space(10.0);
-    egui::ScrollArea::vertical().show(ui, |ui| {
-        if app_data.is_loading {
-            ui.spinner();
-        } else if app_data.search_results.is_empty() {
-            ui.label("検索結果はありません。");
-        } else {
-            for post in &app_data.search_results {
-                // Here you would draw each post.
-                // For now, we'll just show the content as a label.
-                ui.label(&post.content);
-                ui.separator();
+    if app_data.is_loading {
+        ui.spinner();
+    } else if app_data.search_results.is_empty() {
+        ui.label("検索結果はありません。");
+    } else {
+        let num_posts = app_data.search_results.len();
+        let row_height = 90.0; // Adjust as needed
+        let card_frame = egui::Frame {
+            inner_margin: egui::Margin::same(0),
+            corner_radius: 8.0.into(),
+            shadow: eframe::epaint::Shadow::NONE,
+            fill: app_data.current_theme.card_background_color(),
+            ..Default::default()
+        };
+
+        card_frame.show(ui, |ui| {
+            egui::ScrollArea::vertical()
+                .id_salt("search_scroll_area")
+                .max_height(ui.available_height() - 50.0)
+                .show_rows(ui, row_height, num_posts, |ui, row_range| {
+                    for i in row_range {
+                        if let Some(post_data) = app_data.search_results.get(i).cloned() {
+                            post::render_post(ui, app_data, &post_data, &mut urls_to_load);
+                            ui.add_space(5.0);
+                        }
+                    }
+                });
+        });
+    }
+
+    // --- Image Loading Logic ---
+    let cache_db = app_data.cache_db.clone();
+    let mut still_to_load = Vec::new();
+    for (url_key, kind) in urls_to_load {
+        if let Some(image_bytes) = image_cache::load_from_lmdb(&cache_db, &url_key) {
+            if let Ok(mut dynamic_image) = image::load_from_memory(&image_bytes) {
+                let (width, height) = match kind {
+                    ImageKind::Avatar => (32, 32),
+                    ImageKind::Emoji => (20, 20),
+                    _ => (32, 32),
+                };
+                dynamic_image = dynamic_image.thumbnail(width, height);
+                let color_image = egui::ColorImage::from_rgba_unmultiplied(
+                    [
+                        dynamic_image.width() as usize,
+                        dynamic_image.height() as usize,
+                    ],
+                    dynamic_image.to_rgba8().as_flat_samples().as_slice(),
+                );
+                let texture_handle =
+                    ctx.load_texture(&url_key, color_image, Default::default());
+                app_data
+                    .image_cache
+                    .insert(url_key, ImageState::Loaded(texture_handle));
+            } else {
+                app_data.image_cache.insert(url_key, ImageState::Failed);
             }
+        } else {
+            still_to_load.push((url_key, kind));
         }
-    });
+    }
+
+    let data_clone = app_data_arc.clone();
+    for (url_key, kind) in still_to_load {
+        app_data
+            .image_cache
+            .insert(url_key.clone(), ImageState::Loading);
+        app_data.should_repaint = true;
+
+        let app_data_clone = data_clone.clone();
+        let ctx_clone = ctx.clone();
+        let cache_db_for_fetch = app_data.cache_db.clone();
+        let request = ehttp::Request::get(&url_key);
+
+        ehttp::fetch(request, move |result| {
+            let new_state = match result {
+                Ok(response) => {
+                    if response.ok {
+                        image_cache::save_to_lmdb(
+                            &cache_db_for_fetch,
+                            &response.url,
+                            &response.bytes,
+                        );
+
+                        match image::load_from_memory(&response.bytes) {
+                            Ok(mut dynamic_image) => {
+                                let (width, height) = match kind {
+                                    ImageKind::Avatar => (32, 32),
+                                    ImageKind::Emoji => (20, 20),
+                                    _ => (32, 32),
+                                };
+                                dynamic_image = dynamic_image.thumbnail(width, height);
+
+                                let color_image = egui::ColorImage::from_rgba_unmultiplied(
+                                    [
+                                        dynamic_image.width() as usize,
+                                        dynamic_image.height() as usize,
+                                    ],
+                                    dynamic_image.to_rgba8().as_flat_samples().as_slice(),
+                                );
+                                let texture_handle = ctx_clone.load_texture(
+                                    &response.url,
+                                    color_image,
+                                    Default::default(),
+                                );
+                                ImageState::Loaded(texture_handle)
+                            }
+                            Err(_) => ImageState::Failed,
+                        }
+                    } else {
+                        ImageState::Failed
+                    }
+                }
+                Err(_) => ImageState::Failed,
+            };
+
+            let mut app_data = app_data_clone.lock().unwrap();
+            app_data.image_cache.insert(url_key, new_state);
+            ctx_clone.request_repaint();
+        });
+    }
 }


### PR DESCRIPTION
この変更では、投稿レンダリングのロジックを共有モジュール (`ui/post.rs`) にリファクタリングし、異なるビューで再利用できるようにしました。

検索ビューを更新して、この新しい共有レンダリングロジックを使用するようにし、ユーザーのアバター、名前、タイムスタンプを含むタイムラインと同じ形式で検索結果を表示します。これにより、より一貫したユーザーエクスペリエンスが提供されます。