### PR TITLE
feat: Add notifications view

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,7 @@ impl NostrPostApp {
             followed_pubkeys: HashSet::new(),
             followed_pubkeys_display: String::new(),
             timeline_posts: Vec::new(),
+            notification_posts: Vec::new(),
             should_repaint: false,
             is_loading: false,
             current_tab: AppTab::Home,

--- a/src/types.rs
+++ b/src/types.rs
@@ -119,6 +119,7 @@ pub struct TimelinePost {
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum AppTab {
     Home,
+    Notifications,
     Search,
     Wallet,
     Profile,
@@ -177,6 +178,7 @@ pub struct NostrPostAppInternal {
     pub followed_pubkeys: HashSet<PublicKey>,
     pub followed_pubkeys_display: String,
     pub timeline_posts: Vec<TimelinePost>,
+    pub notification_posts: Vec<TimelinePost>,
     pub should_repaint: bool,
     pub is_loading: bool,
     pub current_tab: AppTab,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,5 @@
 pub mod home_view;
+pub mod notifications_view;
 pub mod image_cache;
 pub mod login_view;
 pub mod post;
@@ -21,6 +22,7 @@ impl eframe::App for NostrPostApp {
         let mut app_data = self.data.lock().unwrap();
 
         let home_tab_text = "ホーム";
+        let notifications_tab_text = "通知";
         let search_tab_text = "検索";
         let wallet_tab_text = "ウォレット";
         let profile_tab_text = "プロフィール";
@@ -65,6 +67,11 @@ impl eframe::App for NostrPostApp {
 
                     ui.selectable_value(&mut app_data.current_tab, AppTab::Home, home_tab_text);
                     if app_data.is_logged_in {
+                        ui.selectable_value(
+                            &mut app_data.current_tab,
+                            AppTab::Notifications,
+                            notifications_tab_text,
+                        );
                         ui.selectable_value(
                             &mut app_data.current_tab,
                             AppTab::Search,
@@ -116,6 +123,9 @@ impl eframe::App for NostrPostApp {
                     match app_data.current_tab {
                         AppTab::Home => {
                             home_view::draw_home_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);
+                        },
+                        AppTab::Notifications => {
+                            notifications_view::draw_notifications_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);
                         },
                         AppTab::Search => {
                             search_view::draw_search_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);

--- a/src/ui/notifications_view.rs
+++ b/src/ui/notifications_view.rs
@@ -1,0 +1,299 @@
+use eframe::egui;
+use nostr::{nips::nip19::ToBech32, EventId};
+use std::sync::{Arc, Mutex};
+
+use crate::{
+    nostr_client::fetch_notification_events,
+    types::*,
+    ui::{image_cache, post, zap},
+};
+
+pub fn draw_notifications_view(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    app_data: &mut NostrPostAppInternal,
+    app_data_arc: Arc<Mutex<NostrPostAppInternal>>,
+    runtime_handle: tokio::runtime::Handle,
+) {
+    let mut urls_to_load: Vec<(String, ImageKind)> = Vec::new();
+    let timeline_heading_text = "通知";
+    let fetch_latest_button_text = "通知を更新";
+    let no_timeline_message_text = "通知はまだありません。";
+
+    // --- ZAP Dialog ---
+    if app_data.show_zap_dialog {
+        if let Some(post_to_zap) = app_data.zap_target_post.clone() {
+            let mut close_dialog = false;
+            egui::Window::new("ZAPを送る")
+                .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+                .collapsible(false)
+                .resizable(false)
+                .show(ctx, |ui| {
+                    ui.vertical_centered_justified(|ui| {
+                        ui.add_space(10.0);
+                        let display_name = if !post_to_zap.author_metadata.name.is_empty() {
+                            post_to_zap.author_metadata.name.clone()
+                        } else {
+                            let pubkey = post_to_zap.author_pubkey.to_bech32().unwrap_or_default();
+                            format!("{}...{}", &pubkey[0..8], &pubkey[pubkey.len()-4..])
+                        };
+                        ui.label(format!("{} にZAPします", display_name));
+                        ui.add_space(10.0);
+                        ui.horizontal(|ui| {
+                            ui.label("金額 (sats):");
+                            ui.add(egui::TextEdit::singleline(&mut app_data.zap_amount_input)
+                                .desired_width(120.0));
+                        });
+                        ui.add_space(10.0);
+                    });
+
+                    ui.separator();
+                    ui.add_space(5.0);
+
+                    ui.horizontal(|ui| {
+                        if ui.button("キャンセル").clicked() {
+                           close_dialog = true;
+                        }
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            if ui.button("ZAP").clicked() {
+                                if let (Some(nwc), Some(nwc_client), Some(my_keys)) =
+                                    (app_data.nwc.as_ref(), app_data.nwc_client.as_ref(), app_data.my_keys.as_ref())
+                                {
+                                    if let Ok(amount_sats) = app_data.zap_amount_input.parse::<u64>() {
+                                        let nwc_clone = nwc.clone();
+                                        let nwc_client_clone = nwc_client.clone();
+                                        let my_keys_clone = my_keys.clone();
+                                        let app_data_clone = app_data_arc.clone();
+
+                                        runtime_handle.spawn(async move {
+                                            {
+                                                let mut data = app_data_clone.lock().unwrap();
+                                                data.should_repaint = true;
+                                            } // Lock is dropped here
+
+                                            let result = zap::send_zap_request(
+                                                &nwc_clone,
+                                                &nwc_client_clone,
+                                                &my_keys_clone,
+                                                post_to_zap.author_pubkey,
+                                                &post_to_zap.author_metadata.lud16,
+                                                amount_sats,
+                                                Some(post_to_zap.id),
+                                                Some(post_to_zap.kind),
+                                            ).await;
+
+                                            let mut data = app_data_clone.lock().unwrap();
+                                            match result {
+                                                Ok(_) => {
+                                                    // ZAPリクエストを送信しました。ウォレットの確認を待っています...
+                                                }
+                                                Err(e) => {
+                                                    eprintln!("ZAPエラー: {}", e);
+                                                }
+                                            }
+                                            data.should_repaint = true;
+                                        });
+
+                                        close_dialog = true;
+
+                                    } else {
+                                        eprintln!("無効な金額です");
+                                    }
+                                } else {
+                                    eprintln!("ZAPにはNWCの接続が必要です");
+                                }
+                            }
+                        });
+                    });
+                });
+            if close_dialog {
+                app_data.show_zap_dialog = false;
+                app_data.zap_target_post = None;
+            }
+        }
+    }
+
+    let card_frame = egui::Frame {
+        inner_margin: egui::Margin::same(12),
+        corner_radius: 8.0.into(),
+        shadow: eframe::epaint::Shadow::NONE,
+        fill: app_data.current_theme.card_background_color(),
+        ..Default::default()
+    };
+    card_frame.show(ui, |ui| {
+        ui.horizontal(|ui| {
+            ui.heading(timeline_heading_text);
+
+            let fetch_button = egui::Button::new(egui::RichText::new(fetch_latest_button_text).strong());
+            if ui.add_enabled(!app_data.is_loading, fetch_button).clicked() {
+                if let (Some(client), Some(keys)) = (app_data.nostr_client.as_ref(), app_data.my_keys.as_ref()) {
+                    let client = client.clone();
+                    let my_pubkey = keys.public_key();
+
+                    app_data.is_loading = true;
+                    app_data.should_repaint = true;
+
+                    let cloned_app_data_arc = app_data_arc.clone();
+                    runtime_handle.spawn(async move {
+                        let notification_result = fetch_notification_events(&client, my_pubkey).await;
+
+                        let mut app_data_async = cloned_app_data_arc.lock().unwrap();
+                        app_data_async.is_loading = false;
+                        match notification_result {
+                            Ok(new_posts) => {
+                                if !new_posts.is_empty() {
+                                    let mut existing_ids: std::collections::HashSet<EventId> = app_data_async.notification_posts.iter().map(|p| p.id).collect();
+                                    let mut added_posts = 0;
+                                    for post in new_posts {
+                                        if !existing_ids.contains(&post.id) {
+                                            existing_ids.insert(post.id);
+                                            app_data_async.notification_posts.push(post);
+                                            added_posts += 1;
+                                        }
+                                    }
+
+                                    if added_posts > 0 {
+                                        app_data_async.notification_posts.sort_by_key(|p| std::cmp::Reverse(p.created_at));
+                                        println!("Added {} new notifications.", added_posts);
+                                    } else {
+                                        println!("No new notifications found.");
+                                    }
+                                } else {
+                                    println!("Fetched 0 notifications.");
+                                }
+                            },
+                            Err(e) => {
+                                eprintln!("Failed to fetch notifications: {e}");
+                            }
+                        }
+                        app_data_async.should_repaint = true;
+                    });
+                }
+            }
+
+            if app_data.is_loading {
+                ui.add_space(10.0);
+                ui.spinner();
+                ui.label("更新中...");
+            }
+        });
+        ui.add_space(10.0);
+
+        if app_data.notification_posts.is_empty() {
+            ui.label(no_timeline_message_text);
+        } else {
+            let num_posts = app_data.notification_posts.len();
+            let row_height = 90.0;
+
+            let card_frame = egui::Frame {
+                inner_margin: egui::Margin::same(0),
+                corner_radius: 8.0.into(),
+                shadow: eframe::epaint::Shadow::NONE,
+                fill: app_data.current_theme.card_background_color(),
+                ..Default::default()
+            };
+            card_frame.show(ui, |ui| {
+                egui::ScrollArea::vertical()
+                    .id_salt("notification_scroll_area")
+                    .max_height(ui.available_height() - 100.0)
+                    .show_rows(ui, row_height, num_posts, |ui, row_range| {
+                        for i in row_range {
+                            let post_data = app_data.notification_posts[i].clone();
+                            post::render_post(ui, app_data, &post_data, &mut urls_to_load);
+                            ui.add_space(5.0);
+                        }
+                    });
+            });
+        }
+
+        // --- Image Loading Logic ---
+
+        // First, try to load images from the LMDB cache for URLs not in memory.
+        let cache_db = app_data.cache_db.clone();
+        let mut still_to_load = Vec::new();
+        for (url_key, kind) in urls_to_load {
+            if let Some(image_bytes) = image_cache::load_from_lmdb(&cache_db, &url_key) {
+                // Image found in cache, process it directly.
+                // This is a simplification; for a smoother UI, this should be async.
+                if let Ok(mut dynamic_image) = image::load_from_memory(&image_bytes) {
+                    let (width, height) = match kind {
+                        ImageKind::Avatar => (32, 32),
+                        ImageKind::Emoji => (20, 20),
+                    _ => (32, 32), // Default for Banner, ProfilePicture, etc.
+                    };
+                    dynamic_image = dynamic_image.thumbnail(width, height);
+                    let color_image = egui::ColorImage::from_rgba_unmultiplied(
+                        [dynamic_image.width() as usize, dynamic_image.height() as usize],
+                        dynamic_image.to_rgba8().as_flat_samples().as_slice(),
+                    );
+                    let texture_handle = ctx.load_texture(
+                        &url_key,
+                        color_image,
+                        Default::default()
+                    );
+                    app_data.image_cache.insert(url_key, ImageState::Loaded(texture_handle));
+                } else {
+                    // Failed to decode, mark as failed.
+                    app_data.image_cache.insert(url_key, ImageState::Failed);
+                }
+            } else {
+                // Not on disk, queue for network download.
+                still_to_load.push((url_key, kind));
+            }
+        }
+
+        // Fetch remaining images from the network.
+        let data_clone = app_data_arc.clone();
+        for (url_key, kind) in still_to_load {
+            app_data.image_cache.insert(url_key.clone(), ImageState::Loading);
+            app_data.should_repaint = true;
+
+            let app_data_clone = data_clone.clone();
+            let ctx_clone = ctx.clone();
+            let cache_db_for_fetch = app_data.cache_db.clone();
+            let request = ehttp::Request::get(&url_key);
+
+            ehttp::fetch(request, move |result| {
+                let new_state = match result {
+                    Ok(response) => {
+                        if response.ok {
+                            // Save to LMDB cache first.
+                            image_cache::save_to_lmdb(&cache_db_for_fetch, &response.url, &response.bytes);
+
+                            match image::load_from_memory(&response.bytes) {
+                                Ok(mut dynamic_image) => {
+                                    let (width, height) = match kind {
+                                        ImageKind::Avatar => (32, 32),
+                                        ImageKind::Emoji => (20, 20),
+                                    _ => (32, 32), // Default for Banner, ProfilePicture, etc.
+                                    };
+                                    dynamic_image = dynamic_image.thumbnail(width, height);
+
+                                    let color_image = egui::ColorImage::from_rgba_unmultiplied(
+                                        [dynamic_image.width() as usize, dynamic_image.height() as usize],
+                                        dynamic_image.to_rgba8().as_flat_samples().as_slice(),
+                                    );
+                                    let texture_handle = ctx_clone.load_texture(
+                                        &response.url,
+                                        color_image,
+                                        Default::default()
+                                    );
+                                    ImageState::Loaded(texture_handle)
+                                }
+                                Err(_) => ImageState::Failed,
+                            }
+                        } else {
+                            ImageState::Failed
+                        }
+                    }
+                    Err(_) => ImageState::Failed,
+                };
+
+                let mut app_data = app_data_clone.lock().unwrap();
+                app_data.image_cache.insert(url_key, new_state);
+                ctx_clone.request_repaint();
+            });
+        }
+    });
+
+}


### PR DESCRIPTION
This commit introduces a new notifications feature.

- A 'Notifications' tab is added to the main UI, visible when logged in.
- This view fetches and displays replies and reactions directed to the user.
- Notification events are fetched from the `wss://yabu.me` relay.
- The timeline logic from the home view was adapted for the new notifications feed.