### PR TITLE
feat: Implement profile cache to improve reply loading speed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -264,6 +264,7 @@ impl NostrPostApp {
             search_input: String::new(),
             search_results: Vec::new(),
             quoted_posts_cache: HashMap::new(),
+            profile_cache: HashMap::new(),
             posts_to_fetch: Arc::new(Mutex::new(HashSet::new())),
             profile_posts: Vec::new(),
             is_fetching_profile_posts: false,

--- a/src/types.rs
+++ b/src/types.rs
@@ -229,6 +229,7 @@ pub struct NostrPostAppInternal {
 
     // Quote
     pub quoted_posts_cache: HashMap<EventId, Arc<TimelinePost>>,
+    pub profile_cache: HashMap<PublicKey, ProfileMetadata>,
     pub posts_to_fetch: Arc<Mutex<HashSet<EventId>>>,
 
     // Profile


### PR DESCRIPTION
Adds a `profile_cache` to the main application state to store fetched user profiles.

The logic for fetching replied-to/quoted posts now checks this cache before making a network request for profile metadata.

Newly fetched profiles are stored in the cache to prevent redundant requests for the same user, significantly speeding up the loading process when multiple posts from the same author are viewed.