### PR TITLE
feat: Improve data refresh and caching

### DIFF
--- a/src/cache_db.rs
+++ b/src/cache_db.rs
@@ -14,6 +14,7 @@ pub const DB_RELAYS: &str = "nip65_relays";
 pub const DB_TIMELINE: &str = "timeline_posts";
 pub const DB_NOTIFICATIONS: &str = "notification_posts";
 pub const DB_IMAGES: &str = "images";
+pub const DB_SELF_POSTS: &str = "self_posts";
 
 #[derive(Clone)]
 pub struct LmdbCache {
@@ -25,7 +26,7 @@ impl LmdbCache {
         std::fs::create_dir_all(path)?;
         let mut options = heed::EnvOpenOptions::new();
         options.map_size(1024 * 1024 * 1024); // 1 GB
-        options.max_dbs(8);
+        options.max_dbs(9);
         let env = unsafe { options.open(path)? };
 
         let mut txn = env.write_txn()?;
@@ -35,6 +36,7 @@ impl LmdbCache {
         let _: Database<Str, Bytes> = env.create_database(&mut txn, Some(DB_TIMELINE))?;
         let _: Database<Str, Bytes> = env.create_database(&mut txn, Some(DB_NOTIFICATIONS))?;
         let _: Database<Str, Bytes> = env.create_database(&mut txn, Some(DB_IMAGES))?;
+        let _: Database<Str, Bytes> = env.create_database(&mut txn, Some(DB_SELF_POSTS))?;
         txn.commit()?;
 
         Ok(Self { env: Arc::new(env) })

--- a/src/ui/home_view.rs
+++ b/src/ui/home_view.rs
@@ -526,16 +526,14 @@ pub fn draw_home_view(
                     app_data.should_repaint = true;
 
                     runtime_handle.spawn(async move {
-                        match events::refresh_all_data(&client, &keys, &cache_db, &relay_config).await {
-                            Ok(fresh_data) => {
+                        match events::refresh_timeline(&client, &keys, &cache_db, &relay_config).await {
+                            Ok(timeline_posts) => {
                                 let mut app_data = cloned_app_data_arc.lock().unwrap();
-                                app_data.timeline_posts = fresh_data.timeline_posts;
-                                app_data.notification_posts = fresh_data.notification_posts;
-                                app_data.editable_profile = fresh_data.profile_metadata;
-                                println!("Refreshed all data from home view.");
+                                app_data.timeline_posts = timeline_posts;
+                                println!("Refreshed timeline from home view.");
                             }
                             Err(e) => {
-                                eprintln!("Failed to refresh data: {}", e);
+                                eprintln!("Failed to refresh timeline: {}", e);
                             }
                         }
                         let mut app_data = cloned_app_data_arc.lock().unwrap();

--- a/src/ui/login_view.rs
+++ b/src/ui/login_view.rs
@@ -164,6 +164,17 @@ pub fn draw_login_view(
                             app_data.is_loading = true;
                         }
                         let fresh_data_result = refresh_all_data(&client, &keys, &cache_db_clone, &relay_config).await;
+
+                        // --- Fetch and cache self posts ---
+                        let client_clone = client.clone();
+                        let keys_clone = keys.clone();
+                        let cache_db_clone_for_self_posts = cache_db_clone.clone();
+                        runtime_handle.clone().spawn(async move {
+                            if let Err(e) = crate::ui::events::fetch_and_cache_self_posts(&client_clone, &keys_clone, &cache_db_clone_for_self_posts).await {
+                                eprintln!("Failed to fetch and cache self posts: {}", e);
+                            }
+                        });
+
                         if let Ok(fresh_data) = fresh_data_result {
                             // Get relay status before updating app_data
                             let relays = client.relays().await;
@@ -306,6 +317,17 @@ pub fn draw_login_view(
                         client.connect().await;
 
                         let fresh_data_result = refresh_all_data(&client, &keys, &cache_db_clone, &relay_config).await;
+
+                        // --- Fetch and cache self posts ---
+                        let client_clone = client.clone();
+                        let keys_clone = keys.clone();
+                        let cache_db_clone_for_self_posts = cache_db_clone.clone();
+                        runtime_handle.clone().spawn(async move {
+                            if let Err(e) = crate::ui::events::fetch_and_cache_self_posts(&client_clone, &keys_clone, &cache_db_clone_for_self_posts).await {
+                                eprintln!("Failed to fetch and cache self posts: {}", e);
+                            }
+                        });
+
                         if let Ok(fresh_data) = fresh_data_result {
                             let relays = client.relays().await;
                             let mut status_log =


### PR DESCRIPTION
This commit addresses three issues:
1. Timeline refresh is now done in the background and only fetches timeline data, not all data.
2. Profile fetching now uses cached data if the network request times out.
3. User's own posts are now fetched and cached on login.